### PR TITLE
fix(desktop): 显式安装 rustls ring CryptoProvider，修复 native reporter 线程启动即 panic

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -338,6 +338,15 @@ fn setup_app_menu(app: &mut tauri::App) -> tauri::Result<()> {
 pub fn run() {
     init_tracing();
 
+    // reqwest's "rustls" feature transitively enables rustls/aws-lc-rs, which
+    // coexists with the "ring" feature declared in Cargo.toml. With both crypto
+    // provider features enabled, rustls cannot pick a process-level default and
+    // `ClientConfig::builder()` panics, killing the native WebSocket reporter
+    // thread before any connection is attempted (every later report then fails
+    // with "channel closed"). Install ring explicitly so provider selection is
+    // deterministic.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {


### PR DESCRIPTION
## 问题

桌面端使用 native WebSocket 模式时，日志持续报「**发送窗口信息到通道失败: channel closed**」，且服务端收不到任何连接请求（连 WebSocket 握手都没有）。v2.0.0 官方构建（Windows）可稳定复现。

## 根因

`src-tauri/Cargo.toml` 中同时存在：

- `rustls = { …, features = ["ring"] }`
- `reqwest = { …, features = ["rustls"] }` —— 该 feature 经 `__rustls-aws-lc-rs` 连带启用 `rustls/aws-lc-rs`

Cargo feature 合并后，rustls 0.23 的 `ring` 与 `aws-lc-rs` 两个 CryptoProvider feature 同时生效，而代码中没有任何 `CryptoProvider::install_default()` 调用。按 rustls 文档定义的行为，`ClientConfig::builder()` 此时会直接 panic：

```
thread '<unnamed>' panicked at rustls-0.23.40\src\crypto\mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make
sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

（以上为在 v2.0.0 官方构建上重定向 stderr 实际捕获的 panic 信息。）

由于 `connect_once` 在连接前无条件构建 `Connector::Rustls`，**即使目标是 `ws://` 明文地址也会触发**。panic 使 reporter 线程整体死亡，tokio mpsc 接收端被 drop；Monitor 侧仍持有 sender，于是此后每次窗口变化都触发 `tx.send` 失败——即用户看到的「发送窗口信息到通道失败: channel closed」，且外层重连循环已随线程一起消失，永不自愈。release 构建下 `windows_subsystem = "windows"` 没有控制台，panic 对用户完全不可见，加大了排查难度。

## 修复

在 `run()` 入口显式安装 ring 作为进程级默认 provider（与 Cargo.toml 已声明的 `ring` feature 一致），使 provider 选择变为确定性行为，一行修复、不改变依赖图：

```rust
let _ = rustls::crypto::ring::default_provider().install_default();
```

## 验证

- 基于 v2.0.0 tag 应用同样补丁在 Windows 10 本地构建：panic 消失，native reporter 正常连接（`WebSocket connected: 101 Switching Protocols`），window_info 持续上报，服务端快照实时更新；
- 本分支 `cargo check` 通过（仅存量 warning）。

> 另注：`apps/server` 的 rustls 使用默认 feature（仅 aws-lc-rs 单一 provider），不受此问题影响，故只修桌面端。